### PR TITLE
Support fault injection feature

### DIFF
--- a/example/example-fault-injection.yml
+++ b/example/example-fault-injection.yml
@@ -1,0 +1,29 @@
+version: 1
+listener:
+  address: tcp://0.0.0.0:9211
+  access_log_path: /dev/stdout
+  additional_http_filters:
+  - name: envoy.fault
+    config:
+      abort:
+        percent: 0
+        http_status: 503
+admin:
+  address: tcp://0.0.0.0:9901
+  access_log_path: /dev/stdout
+discovery_service:
+  lb: nginx:80
+  tls: false
+  refresh_delay_ms: 10000
+  connect_timeout_ms: 100
+sds:
+  lb: sds:8080
+  tls: false
+  refresh_delay_ms: 1000
+  connect_timeout_ms: 1500
+statsd:
+  address: statsd-exporter:9125
+runtime:
+  symlink_root: /srv/runtime/current
+  subdirectory: envoy
+  override_subdirectory: envoy_override

--- a/lib/schemas/envoy.json
+++ b/lib/schemas/envoy.json
@@ -32,6 +32,19 @@
         "access_log_path": {
           "type": "string",
           "id": "/properties/listener/properties/access_log_path"
+        },
+        "additional_http_filters": {
+          "type": "array",
+          "id": "/properties/listener/properties/additional_http_filters",
+          "additionalProperties": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "name",
+              "config"
+            ]
+          }
         }
       }
     },
@@ -125,6 +138,11 @@
           "id": "/properties/statsd/properties/address"
         }
       }
+    },
+    "runtime": {
+      "type": "object",
+      "id": "/properties/runtime",
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
I would like to do fault injection by using Envoy with [runtime configuration](https://www.envoyproxy.io/docs/envoy/latest/configuration/runtime#config-runtime) for Chaos Engineering.
To enable fault injection by using kumonos, there needs to enable to describe runtime configuration and [fault filter](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/fault/v2/fault.proto) configuration.
What is actually needed is to describe fault filter configuration, but Envoy’s http filter configuration are order-dependent, so I implemented to enable that as additional http filter setting.

@taiki45 Could you please review?
