### PR TITLE
Configure SNI when TLS is enabled and SDS is disabled

### DIFF
--- a/lib/kumonos/clusters.rb
+++ b/lib/kumonos/clusters.rb
@@ -48,7 +48,10 @@ module Kumonos
 
         h[:lb_type] = 'round_robin'
         h.delete(:tls)
-        h[:ssl_context] = {} if tls
+        if tls
+          h[:ssl_context] = {}
+          h[:ssl_context][:sni] = lb.split(':', 2)[0] unless use_sds
+        end
 
         h.delete(:circuit_breaker)
         h[:circuit_breakers] = { default: circuit_breaker.to_h }

--- a/spec/clusters_spec.rb
+++ b/spec/clusters_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe Kumonos::Clusters do
           connect_timeout_ms: 250,
           type: 'strict_dns',
           lb_type: 'round_robin',
-          ssl_context: {},
+          ssl_context: {
+            sni: 'example.com'
+          },
           hosts: [{ url: 'tcp://example.com:443' }],
           circuit_breakers: {
             default: {


### PR DESCRIPTION
Envoy's upstream cluster can have multiple hosts in general, but kumonos
guarantees the host is single when `lb` is specified. In this case, SNI
can be configured without any harm.

@taiki45 @wata-gh @cookpad/dev-infra please review