### PR TITLE
Specify rack version

### DIFF
--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     mustermann (1.0.2)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.3)
       rack
     sinatra (2.0.3)


### PR DESCRIPTION
Specify rack version in test app because rack (`< 2.0.6`) has vulnerabilities.

- https://nvd.nist.gov/vuln/detail/CVE-2018-16470
- https://nvd.nist.gov/vuln/detail/CVE-2018-16471